### PR TITLE
Fix rendering + Improve performance

### DIFF
--- a/src/HelloWorld.tsx
+++ b/src/HelloWorld.tsx
@@ -1,50 +1,47 @@
-import {interpolate} from 'remotion'
-import { CanvasKitView, useDrawCallback } from './components/CanvasKit';
-import { useVideoConfig } from 'remotion';
-import { useLoop, toDeg, mix, polar2Canvas } from './components/Helpers';
+import {interpolate, useVideoConfig} from 'remotion';
+import {CanvasKitView, useDrawCallback} from './components/CanvasKit';
+import {mix, polar2Canvas, toDeg, useLoop} from './components/Helpers';
 
-	
 export const HelloWorld = () => {
 	const {width, height} = useVideoConfig();
-	const center = { x: width/2, y: height/2 };
+	const center = {x: width / 2, y: height / 2};
 	const progress = useLoop(30 * 3, true);
-	const onDraw = useDrawCallback((CanvasKit, canvas) => {
-		const c1 = CanvasKit.parseColorString("#61bea2");
-		const c2 = CanvasKit.parseColorString("#529ca0");
-		const paint = new CanvasKit.Paint();
-		paint.setBlendMode(CanvasKit.BlendMode.Screen);
-		canvas.save();
-		canvas.translate(center.x, center.y);
-		canvas.rotate(toDeg(mix(progress, -Math.PI, 0)), 0, 0);
-		canvas.translate(-center.x, -center.y);
-		const SIZE = width / 2;
-		new Array(6).fill(0).map((_, index) => {
-			const theta = (index * (2 * Math.PI)) / 6;
-			const { x, y } = polar2Canvas(
-				{ theta, radius: SIZE / 2 },
-				{ x: 0, y: 0 }
-			);
-			const translateX = mix(progress, 0, x);
-			const translateY = mix(progress, 0, y);
-			const scale = mix(progress, 0.3, 1);
-			paint.setMaskFilter(CanvasKit.MaskFilter.MakeBlur(
-					CanvasKit.BlurStyle.Solid,
-					interpolate(progress, [0, 0.5, 1], [0, 45, 30]),
-					false
-				)
-			);
-			paint.setColor(index % 2 ? c1 : c2);
+	const onDraw = useDrawCallback(
+		(CanvasKit, canvas) => {
+			const c1 = CanvasKit.parseColorString('#61bea2');
+			const c2 = CanvasKit.parseColorString('#529ca0');
+			const paint = new CanvasKit.Paint();
+			paint.setBlendMode(CanvasKit.BlendMode.Screen);
 			canvas.save();
 			canvas.translate(center.x, center.y);
-			canvas.translate(translateX, translateY);
-			canvas.scale(scale, scale);
+			canvas.rotate(toDeg(mix(progress, -Math.PI, 0)), 0, 0);
 			canvas.translate(-center.x, -center.y);
-			canvas.drawCircle(center.x, center.y, SIZE / 2, paint);
+			const SIZE = width / 2;
+			new Array(6).fill(0).map((_, index) => {
+				const theta = (index * (2 * Math.PI)) / 6;
+				const {x, y} = polar2Canvas({theta, radius: SIZE / 2}, {x: 0, y: 0});
+				const translateX = mix(progress, 0, x);
+				const translateY = mix(progress, 0, y);
+				const scale = mix(progress, 0.3, 1);
+				paint.setMaskFilter(
+					CanvasKit.MaskFilter.MakeBlur(
+						CanvasKit.BlurStyle.Solid,
+						interpolate(progress, [0, 0.5, 1], [0, 45, 30]),
+						false
+					)
+				);
+				paint.setColor(index % 2 ? c1 : c2);
+				canvas.save();
+				canvas.translate(center.x, center.y);
+				canvas.translate(translateX, translateY);
+				canvas.scale(scale, scale);
+				canvas.translate(-center.x, -center.y);
+				canvas.drawCircle(center.x, center.y, SIZE / 2, paint);
+				canvas.restore();
+			});
 			canvas.restore();
-		});
-		canvas.restore();
-	}, [center.x, center.y, progress, width]);
-	return (
-		<CanvasKitView onDraw={onDraw} />
+		},
+		[center.x, center.y, progress, width]
 	);
+	return <CanvasKitView onDraw={onDraw} />;
 };

--- a/src/components/CanvasKit.tsx
+++ b/src/components/CanvasKit.tsx
@@ -1,63 +1,87 @@
-import {useVideoConfig} from 'remotion'
-import { useState, useEffect, useCallback } from 'react';
-import CanvasKitInit, {CanvasKit, Canvas} from "canvaskit-wasm";
-import { createContext, ReactNode, useContext } from "react";
-import {continueRender, delayRender} from 'remotion';
+import CanvasKitInit, {Canvas, CanvasKit, Surface} from 'canvaskit-wasm';
+import {
+	createContext,
+	ReactNode,
+	useCallback,
+	useContext,
+	useEffect,
+	useRef,
+	useState,
+} from 'react';
+import {useVideoConfig} from 'remotion';
 
 export type CanvasKitContext = null | CanvasKit;
 
 const CanvasKitContext = createContext<CanvasKitContext>(null);
 
 export const useCanvasKit = () => {
-  const canvaskit = useContext(CanvasKitContext); 
-  return canvaskit;
-}
+	const canvaskit = useContext(CanvasKitContext);
+	return canvaskit;
+};
 
 interface CanvasKitProviderProps {
-  children: ReactNode | ReactNode[];
+	children: ReactNode | ReactNode[];
 }
 
 export const CanvasKitProvider = ({children}: CanvasKitProviderProps) => {
-  const [canvaskit, setCanvaskit] = useState<CanvasKitContext>(null);
-  useEffect(() => {
-    CanvasKitInit().then(ck => {
-      setCanvaskit(ck);
-    });
-  }, []);
-  return (
-	<CanvasKitContext.Provider value={canvaskit}>
-		{children}
-	</CanvasKitContext.Provider>
-  )
+	const [canvaskit, setCanvaskit] = useState<CanvasKitContext>(null);
+	useEffect(() => {
+		CanvasKitInit().then((ck) => {
+			setCanvaskit(ck);
+		});
+	}, []);
+	return (
+		<CanvasKitContext.Provider value={canvaskit}>
+			{children}
+		</CanvasKitContext.Provider>
+	);
 };
 
-type DrawCallback = (CanvasKit: CanvasKit, canvas: Canvas) => void
+type DrawCallback = (CanvasKit: CanvasKit, canvas: Canvas) => void;
 
 interface CanvasKitViewProps {
-  onDraw: DrawCallback;
+	onDraw: DrawCallback;
 }
 
 // eslint-disable-next-line react-hooks/exhaustive-deps
-export const useDrawCallback = (cb: DrawCallback, deps: Parameters<typeof useCallback>[1]) => useCallback(cb, deps);
+export const useDrawCallback = (
+	cb: DrawCallback,
+	deps: Parameters<typeof useCallback>[1]
+) => useCallback(cb, deps);
 
 export const CanvasKitView = ({onDraw}: CanvasKitViewProps) => {
-  const {width,height} = useVideoConfig();
-  const CanvasKit = useCanvasKit();
+	const {width, height} = useVideoConfig();
+	const ref = useRef<HTMLCanvasElement>(null);
+	const CanvasKit = useCanvasKit();
+
+	const [skia, setSkia] = useState<{
+		surface: Surface;
+		canvas: Canvas;
+	} | null>(null);
+
 	useEffect(() => {
-		if (CanvasKit) {
-			const surface = CanvasKit.MakeCanvasSurface("canvas");
+		if (CanvasKit && ref.current) {
+			const surface = CanvasKit.MakeCanvasSurface(ref.current);
 			if (!surface) {
-				throw "Could not make surface";
+				throw 'Could not make surface';
 			}
-			const canvas = surface.getCanvas();
-      const t0 = performance.now();
-      onDraw(CanvasKit, canvas);
-      surface.flush();
-      const t1 = performance.now();
-      console.log("Draw frame (ms): " + Math.round(t1-t0));
-    }
-  }, [CanvasKit, onDraw]);
-  return (
-	  <canvas id="canvas" width={width} height={height} />
-  );
-}
+			setSkia({
+				surface,
+				canvas: surface.getCanvas(),
+			});
+		}
+	}, [CanvasKit]);
+
+	useEffect(() => {
+		if (!CanvasKit || !skia) {
+			return;
+		}
+		const {canvas, surface} = skia;
+		const t0 = performance.now();
+		onDraw(CanvasKit, canvas);
+		surface.flush();
+		const t1 = performance.now();
+		console.log('time to draw', t1 - t0);
+	}, [CanvasKit, onDraw, skia]);
+	return <canvas ref={ref} width={width} height={height} />;
+};


### PR DESCRIPTION
It's unfortunate, but we were querying `document.getElementById("canvas")`, but this is the ID of the container that Remotion is rendering the video into (just made a commit to rename it to avoid these collisions). I refactored to a ref to fix the rendering.

Also reduced the calls to `getSurface()` to improve the rendering time by a lot! Let's gooooo


https://user-images.githubusercontent.com/1629785/135653144-2c9cdaf4-3d29-48e9-b91d-5381a2bf59bf.mp4



